### PR TITLE
Fixed a spelling mistake in README.md

### DIFF
--- a/04_Self_Healing/README.md
+++ b/04_Self_Healing/README.md
@@ -5,7 +5,7 @@
 In this use case you will learn how to use the capabilities of Keptn to provide self-healing for an application without modifying any of the applications code. The use case presented in the following will scale up the pods of an application if the application undergoes heavy CPU saturation.
 
 ## Prerequisites
-A couple of specifications files are needed for Keptn to actually know which remediation to perofrm and to verify if the executed remediation was successful.
+A couple of specifications files are needed for Keptn to actually know which remediation to perform and to verify if the executed remediation was successful.
 
 Please that as of now, this tutorial only works out of the box with Prometheus as the tool for monitoring your cluster. Support for Dynatrace will follow.
 


### PR DESCRIPTION
changed 'perofrm' to 'perform'